### PR TITLE
Migrate Phosphor icon component names to Icon-suffixed variants

### DIFF
--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -35,13 +35,13 @@ import { pathSync } from "@/lib/path";
 import type { MainFileDetectionResult } from "@/lib/latex/types";
 import type { PendingEdit } from "@/lib/opencode/types";
 import {
-  ArrowClockwise,
-  FilePlus,
-  Folder,
-  FolderPlus,
-  Gear,
-  GitBranch,
-  PlayCircle,
+  ArrowClockwiseIcon,
+  FilePlusIcon,
+  FolderIcon,
+  FolderPlusIcon,
+  GearIcon,
+  GitBranchIcon,
+  PlayCircleIcon,
 } from "@phosphor-icons/react";
 
 function throttle<T extends (...args: Parameters<T>) => void>(
@@ -1405,7 +1405,7 @@ The AI assistant will read and update this file during compilation.
                     }`}
                     title="Compile (Ctrl+Shift+B)"
                   >
-                    <PlayCircle className="size-4" />
+                    <PlayCircleIcon className="size-4" />
                   </button>
 
                   <button
@@ -1414,7 +1414,7 @@ The AI assistant will read and update this file during compilation.
                     title="LaTeX Settings"
                     aria-label="LaTeX Settings"
                   >
-                    <Gear className="size-4" />
+                    <GearIcon className="size-4" />
                   </button>
                 </div>
               </>
@@ -1498,7 +1498,7 @@ The AI assistant will read and update this file during compilation.
                               title="New File"
                               aria-label="New File"
                             >
-                              <FilePlus className="w-4 h-4" />
+                              <FilePlusIcon className="w-4 h-4" />
                             </button>
                             <button
                               onClick={() =>
@@ -1508,7 +1508,7 @@ The AI assistant will read and update this file during compilation.
                               title="New Folder"
                               aria-label="New Folder"
                             >
-                              <FolderPlus className="w-4 h-4" />
+                              <FolderPlusIcon className="w-4 h-4" />
                             </button>
                             <button
                               onClick={() => daemon.refreshFiles()}
@@ -1516,7 +1516,7 @@ The AI assistant will read and update this file during compilation.
                               title="Refresh Files"
                               aria-label="Refresh Files"
                             >
-                              <ArrowClockwise className="w-4 h-4" />
+                              <ArrowClockwiseIcon className="w-4 h-4" />
                             </button>
                           </div>
                         </div>
@@ -1540,7 +1540,7 @@ The AI assistant will read and update this file during compilation.
                       </>
                     ) : (
                       <div className="flex-1 flex flex-col items-center justify-center p-4 text-center text-muted">
-                        <Folder className="w-8 h-8 mb-2 opacity-30" />
+                        <FolderIcon className="w-8 h-8 mb-2 opacity-30" />
                         <p className="text-xs">No folder open</p>
                       </div>
                     )}
@@ -1551,12 +1551,12 @@ The AI assistant will read and update this file during compilation.
                   <div className="flex-1 flex flex-col overflow-hidden">
                     {!daemon.projectPath ? (
                       <div className="flex-1 flex flex-col items-center justify-center p-4 text-center text-muted">
-                        <GitBranch className="w-8 h-8 mb-2 opacity-30" />
+                        <GitBranchIcon className="w-8 h-8 mb-2 opacity-30" />
                         <p className="text-xs">No folder open</p>
                       </div>
                     ) : !gitStatus?.isRepo ? (
                       <div className="flex-1 flex flex-col items-center justify-center p-4 text-center text-muted">
-                        <GitBranch className="w-8 h-8 mb-2 opacity-30" />
+                        <GitBranchIcon className="w-8 h-8 mb-2 opacity-30" />
                         <p className="text-xs mb-3">Not a git repository</p>
                         <button
                           onClick={() => daemon.gitInit()}
@@ -1580,7 +1580,7 @@ The AI assistant will read and update this file during compilation.
                               className="text-muted hover:text-black"
                               aria-label="Refresh git status"
                             >
-                              <ArrowClockwise className="w-4 h-4" />
+                              <ArrowClockwiseIcon className="w-4 h-4" />
                             </button>
                           </div>
                           {!gitStatus.remote && (
@@ -1845,7 +1845,7 @@ The AI assistant will read and update this file during compilation.
                       className="flex items-center gap-1.5 px-2 py-1 text-xs text-neutral-600 hover:text-neutral-900 hover:bg-neutral-200 rounded transition-colors"
                       title="Refresh PDF"
                     >
-                      <ArrowClockwise className="w-3.5 h-3.5" />
+                      <ArrowClockwiseIcon className="w-3.5 h-3.5" />
                       Refresh
                     </button>
                   </div>

--- a/apps/desktop/src/components/auth/login-code-modal.tsx
+++ b/apps/desktop/src/components/auth/login-code-modal.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
-  ArrowSquareOut,
-  Check,
-  CircleNotch,
-  Copy,
-  X,
+  ArrowSquareOutIcon,
+  CheckIcon,
+  CircleNotchIcon,
+  CopyIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import { getSupabaseClient } from "@/lib/supabase";
 import { invoke } from "@tauri-apps/api/core";
@@ -326,7 +326,7 @@ export function LoginCodeModal({ isOpen, onClose, onSuccess, loginUrl: baseLogin
             disabled={isLoading}
             className="p-1 hover:bg-neutral-100 transition-colors disabled:opacity-50"
           >
-            <X className="w-5 h-5" />
+            <XIcon className="w-5 h-5" />
           </button>
         </div>
 
@@ -347,9 +347,9 @@ export function LoginCodeModal({ isOpen, onClose, onSuccess, loginUrl: baseLogin
                   title="Copy link"
                 >
                   {linkCopied ? (
-                    <Check className="w-3.5 h-3.5 text-green-600" />
+                    <CheckIcon className="w-3.5 h-3.5 text-green-600" />
                   ) : (
-                    <Copy className="w-3.5 h-3.5" />
+                    <CopyIcon className="w-3.5 h-3.5" />
                   )}
                 </button>
                 <button
@@ -357,7 +357,7 @@ export function LoginCodeModal({ isOpen, onClose, onSuccess, loginUrl: baseLogin
                   className="p-1 text-muted hover:text-black hover:bg-neutral-200 transition-colors"
                   title="Open in browser"
                 >
-                  <ArrowSquareOut className="w-3.5 h-3.5" />
+                  <ArrowSquareOutIcon className="w-3.5 h-3.5" />
                 </button>
               </div>
             </div>
@@ -408,12 +408,12 @@ export function LoginCodeModal({ isOpen, onClose, onSuccess, loginUrl: baseLogin
             >
               {isSuccess ? (
                 <>
-                  <Check className="w-4 h-4" />
+                  <CheckIcon className="w-4 h-4" />
                   Success!
                 </>
               ) : isLoading ? (
                 <>
-                  <CircleNotch className="w-4 h-4 animate-spin" />
+                  <CircleNotchIcon className="w-4 h-4 animate-spin" />
                   Logging in...
                 </>
               ) : (

--- a/apps/desktop/src/components/auth/user-dropdown.tsx
+++ b/apps/desktop/src/components/auth/user-dropdown.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ArrowRight, CaretDown, CaretRight } from "@phosphor-icons/react";
+import {
+  ArrowRightIcon,
+  CaretDownIcon,
+  CaretRightIcon,
+} from "@phosphor-icons/react";
 import { useAuth, type UserProfile } from "@/lib/auth";
 
 type Props = {
@@ -85,7 +89,7 @@ export function UserDropdown({ profile }: Props) {
             </span>
           </div>
         )}
-        <CaretDown
+        <CaretDownIcon
           className={`size-4 text-muted transition-transform ${isOpen ? "rotate-180" : ""}`}
         />
       </button>
@@ -117,7 +121,7 @@ export function UserDropdown({ profile }: Props) {
               {name && <p className="font-medium truncate">{name}</p>}
               <p className="text-sm text-muted truncate">{email}</p>
             </div>
-            <CaretRight className="size-4 text-muted group-hover:text-black transition-colors flex-shrink-0" />
+            <CaretRightIcon className="size-4 text-muted group-hover:text-black transition-colors flex-shrink-0" />
           </button>
 
           <div className="px-5 py-4 border-b border-border bg-neutral-50">
@@ -150,7 +154,7 @@ export function UserDropdown({ profile }: Props) {
                 </span>
                 <span className="inline-flex items-center gap-1 text-xs font-medium text-muted group-hover:text-black transition-colors">
                   Unlock
-                  <ArrowRight className="size-3" weight="bold" />
+                  <ArrowRightIcon className="size-3" weight="bold" />
                 </span>
               </button>
             )}

--- a/apps/desktop/src/components/editor/changes-review-panel.tsx
+++ b/apps/desktop/src/components/editor/changes-review-panel.tsx
@@ -3,7 +3,13 @@
 import { useState, useCallback, useEffect, useMemo, memo } from "react";
 import dynamic from "next/dynamic";
 import type { PendingEdit } from "@/lib/opencode/types";
-import { CaretLeft, CaretRight, Check, CheckCircle, X } from "@phosphor-icons/react";
+import {
+  CaretLeftIcon,
+  CaretRightIcon,
+  CheckIcon,
+  CheckCircleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 
 const MonacoDiffEditor = dynamic(
   () =>
@@ -181,7 +187,7 @@ export const ChangesReviewPanel = memo(function ChangesReviewPanel({
       <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-200 bg-amber-50">
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <CheckCircle className="w-4 h-4 text-amber-600" />
+            <CheckCircleIcon className="w-4 h-4 text-amber-600" />
             <span className="text-sm font-medium text-amber-800">
               Review Changes
             </span>
@@ -250,10 +256,10 @@ export const ChangesReviewPanel = memo(function ChangesReviewPanel({
               >
                 <div className="flex items-center gap-2">
                   {edit.status === "accepted" && (
-                    <Check className="w-3 h-3 text-green-600 flex-shrink-0" />
+                    <CheckIcon className="w-3 h-3 text-green-600 flex-shrink-0" />
                   )}
                   {edit.status === "rejected" && (
-                    <X className="w-3 h-3 text-red-500 flex-shrink-0" />
+                    <XIcon className="w-3 h-3 text-red-500 flex-shrink-0" />
                   )}
                   {edit.status === "pending" && (
                     <span className="w-2 h-2 bg-amber-500 rounded-full flex-shrink-0" />
@@ -302,7 +308,7 @@ export const ChangesReviewPanel = memo(function ChangesReviewPanel({
                   disabled={currentIndex === 0 || isProcessing}
                   className="p-1 text-neutral-500 hover:text-neutral-900 disabled:opacity-30 disabled:cursor-not-allowed"
                 >
-                  <CaretLeft className="w-4 h-4" />
+                  <CaretLeftIcon className="w-4 h-4" />
                 </button>
                 <span className="text-xs text-neutral-500 font-mono tabular-nums">
                   {currentIndex + 1} / {totalCount}
@@ -312,7 +318,7 @@ export const ChangesReviewPanel = memo(function ChangesReviewPanel({
                   disabled={currentIndex === edits.length - 1 || isProcessing}
                   className="p-1 text-neutral-500 hover:text-neutral-900 disabled:opacity-30 disabled:cursor-not-allowed"
                 >
-                  <CaretRight className="w-4 h-4" />
+                  <CaretRightIcon className="w-4 h-4" />
                 </button>
               </div>
               <span className="text-sm font-mono text-neutral-700 truncate">

--- a/apps/desktop/src/components/editor/editor-error-boundary.tsx
+++ b/apps/desktop/src/components/editor/editor-error-boundary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Component, ErrorInfo, ReactNode } from "react";
-import { Warning } from "@phosphor-icons/react";
+import { WarningIcon } from "@phosphor-icons/react";
 
 type Props = {
   children: ReactNode;
@@ -37,7 +37,7 @@ export class EditorErrorBoundary extends Component<Props, State> {
       return (
         <div className="h-full flex flex-col items-center justify-center p-6 text-center">
           <div className="size-12 border border-neutral-300 flex items-center justify-center mb-4">
-            <Warning className="size-6 text-neutral-400" />
+            <WarningIcon className="size-6 text-neutral-400" />
           </div>
           <h3 className="text-sm font-medium text-neutral-900 mb-1">
             Editor Component Error

--- a/apps/desktop/src/components/editor/file-tree.tsx
+++ b/apps/desktop/src/components/editor/file-tree.tsx
@@ -96,31 +96,31 @@ import type { FileNode } from "@lmms-lab/writer-shared";
 import { ContextMenu, type ContextMenuItem } from "../ui/context-menu";
 import { InputDialog } from "../ui/input-dialog";
 import {
-  Archive,
-  ArrowClockwise,
-  ArrowSquareOut,
-  BookOpenText,
-  BracketsCurly,
-  CaretRight,
+  ArchiveIcon,
+  ArrowClockwiseIcon,
+  ArrowSquareOutIcon,
+  BookOpenTextIcon,
+  BracketsCurlyIcon,
+  CaretRightIcon,
   ClipboardTextIcon,
   CopyIcon,
-  Cube,
-  File,
-  FileCode,
-  FilePlus,
-  FileText,
-  Folder,
-  FolderOpen,
-  FolderPlus,
-  Gear,
-  Image,
-  MusicNote,
-  PencilLine,
-  Table,
-  Terminal,
+  CubeIcon,
+  FileCodeIcon,
+  FileIcon as FileIconSymbol,
+  FilePlusIcon,
+  FileTextIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  FolderPlusIcon,
+  GearIcon,
+  ImageIcon,
+  MusicNoteIcon,
+  PencilLineIcon,
+  TableIcon,
+  TerminalIcon,
   TerminalWindowIcon,
-  Trash,
-  VideoCamera,
+  TrashIcon,
+  VideoCameraIcon,
 } from "@phosphor-icons/react";
 
 export interface FileOperations {
@@ -164,119 +164,119 @@ type IconType = React.ComponentType<{ className?: string; size?: number }>;
 
 const FILE_ICON_MAP: Record<string, IconType> = {
   // LaTeX source files
-  ".tex": FileText,
-  ".ltx": FileText,
+  ".tex": FileTextIcon,
+  ".ltx": FileTextIcon,
   // LaTeX bibliography
-  ".bib": BookOpenText,
+  ".bib": BookOpenTextIcon,
   // LaTeX document class (template)
-  ".cls": Cube,
+  ".cls": CubeIcon,
   // LaTeX style packages
-  ".sty": Cube,
+  ".sty": CubeIcon,
   // LaTeX package source
-  ".dtx": Cube,
-  ".ins": Cube,
+  ".dtx": CubeIcon,
+  ".ins": CubeIcon,
   // LaTeX output
-  ".pdf": File,
-  ".dvi": File,
-  ".ps": File,
+  ".pdf": FileIconSymbol,
+  ".dvi": FileIconSymbol,
+  ".ps": FileIconSymbol,
   // LaTeX config
-  ".latexmkrc": Gear,
+  ".latexmkrc": GearIcon,
   // Documents
-  ".doc": FileText,
-  ".docx": FileText,
-  ".txt": FileText,
-  ".rtf": FileText,
-  ".md": FileText,
-  ".mdx": FileText,
-  ".rst": FileText,
+  ".doc": FileTextIcon,
+  ".docx": FileTextIcon,
+  ".txt": FileTextIcon,
+  ".rtf": FileTextIcon,
+  ".md": FileTextIcon,
+  ".mdx": FileTextIcon,
+  ".rst": FileTextIcon,
   // Code
-  ".js": FileCode,
-  ".jsx": FileCode,
-  ".ts": FileCode,
-  ".tsx": FileCode,
-  ".mjs": FileCode,
-  ".cjs": FileCode,
-  ".py": FileCode,
-  ".rb": FileCode,
-  ".go": FileCode,
-  ".rs": FileCode,
-  ".c": FileCode,
-  ".cpp": FileCode,
-  ".h": FileCode,
-  ".hpp": FileCode,
-  ".java": FileCode,
-  ".kt": FileCode,
-  ".swift": FileCode,
-  ".lua": FileCode,
-  ".r": FileCode,
-  ".m": FileCode,
-  ".html": FileCode,
-  ".htm": FileCode,
-  ".css": FileCode,
-  ".scss": FileCode,
-  ".sass": FileCode,
-  ".less": FileCode,
-  ".vue": FileCode,
-  ".svelte": FileCode,
+  ".js": FileCodeIcon,
+  ".jsx": FileCodeIcon,
+  ".ts": FileCodeIcon,
+  ".tsx": FileCodeIcon,
+  ".mjs": FileCodeIcon,
+  ".cjs": FileCodeIcon,
+  ".py": FileCodeIcon,
+  ".rb": FileCodeIcon,
+  ".go": FileCodeIcon,
+  ".rs": FileCodeIcon,
+  ".c": FileCodeIcon,
+  ".cpp": FileCodeIcon,
+  ".h": FileCodeIcon,
+  ".hpp": FileCodeIcon,
+  ".java": FileCodeIcon,
+  ".kt": FileCodeIcon,
+  ".swift": FileCodeIcon,
+  ".lua": FileCodeIcon,
+  ".r": FileCodeIcon,
+  ".m": FileCodeIcon,
+  ".html": FileCodeIcon,
+  ".htm": FileCodeIcon,
+  ".css": FileCodeIcon,
+  ".scss": FileCodeIcon,
+  ".sass": FileCodeIcon,
+  ".less": FileCodeIcon,
+  ".vue": FileCodeIcon,
+  ".svelte": FileCodeIcon,
   // Shell/Scripts
-  ".sh": Terminal,
-  ".bash": Terminal,
-  ".zsh": Terminal,
-  ".fish": Terminal,
-  ".ps1": Terminal,
-  ".bat": Terminal,
-  ".cmd": Terminal,
+  ".sh": TerminalIcon,
+  ".bash": TerminalIcon,
+  ".zsh": TerminalIcon,
+  ".fish": TerminalIcon,
+  ".ps1": TerminalIcon,
+  ".bat": TerminalIcon,
+  ".cmd": TerminalIcon,
   // Config/Data
-  ".json": BracketsCurly,
-  ".yaml": BracketsCurly,
-  ".yml": BracketsCurly,
-  ".toml": BracketsCurly,
-  ".xml": BracketsCurly,
-  ".ini": Gear,
-  ".cfg": Gear,
-  ".conf": Gear,
-  ".env": Gear,
-  ".gitignore": Gear,
-  ".editorconfig": Gear,
-  ".prettierrc": Gear,
-  ".eslintrc": Gear,
+  ".json": BracketsCurlyIcon,
+  ".yaml": BracketsCurlyIcon,
+  ".yml": BracketsCurlyIcon,
+  ".toml": BracketsCurlyIcon,
+  ".xml": BracketsCurlyIcon,
+  ".ini": GearIcon,
+  ".cfg": GearIcon,
+  ".conf": GearIcon,
+  ".env": GearIcon,
+  ".gitignore": GearIcon,
+  ".editorconfig": GearIcon,
+  ".prettierrc": GearIcon,
+  ".eslintrc": GearIcon,
   // Images
-  ".png": Image,
-  ".jpg": Image,
-  ".jpeg": Image,
-  ".gif": Image,
-  ".svg": Image,
-  ".webp": Image,
-  ".ico": Image,
-  ".bmp": Image,
-  ".tiff": Image,
-  ".tif": Image,
-  ".eps": Image,
-  ".pgf": Image,
-  ".tikz": Image,
+  ".png": ImageIcon,
+  ".jpg": ImageIcon,
+  ".jpeg": ImageIcon,
+  ".gif": ImageIcon,
+  ".svg": ImageIcon,
+  ".webp": ImageIcon,
+  ".ico": ImageIcon,
+  ".bmp": ImageIcon,
+  ".tiff": ImageIcon,
+  ".tif": ImageIcon,
+  ".eps": ImageIcon,
+  ".pgf": ImageIcon,
+  ".tikz": ImageIcon,
   // Archives
-  ".zip": Archive,
-  ".tar": Archive,
-  ".gz": Archive,
-  ".rar": Archive,
-  ".7z": Archive,
+  ".zip": ArchiveIcon,
+  ".tar": ArchiveIcon,
+  ".gz": ArchiveIcon,
+  ".rar": ArchiveIcon,
+  ".7z": ArchiveIcon,
   // Video
-  ".mp4": VideoCamera,
-  ".mkv": VideoCamera,
-  ".avi": VideoCamera,
-  ".mov": VideoCamera,
-  ".webm": VideoCamera,
+  ".mp4": VideoCameraIcon,
+  ".mkv": VideoCameraIcon,
+  ".avi": VideoCameraIcon,
+  ".mov": VideoCameraIcon,
+  ".webm": VideoCameraIcon,
   // Audio
-  ".mp3": MusicNote,
-  ".wav": MusicNote,
-  ".flac": MusicNote,
-  ".ogg": MusicNote,
-  ".m4a": MusicNote,
+  ".mp3": MusicNoteIcon,
+  ".wav": MusicNoteIcon,
+  ".flac": MusicNoteIcon,
+  ".ogg": MusicNoteIcon,
+  ".m4a": MusicNoteIcon,
   // Spreadsheet/Data
-  ".csv": Table,
-  ".xls": Table,
-  ".xlsx": Table,
-  ".tsv": Table,
+  ".csv": TableIcon,
+  ".xls": TableIcon,
+  ".xlsx": TableIcon,
+  ".tsv": TableIcon,
 };
 
 function FileIcon({
@@ -292,14 +292,14 @@ function FileIcon({
 
   if (type === "directory") {
     return expanded ? (
-      <FolderOpen className={iconClass} size={16} />
+      <FolderOpenIcon className={iconClass} size={16} />
     ) : (
-      <Folder className={iconClass} size={16} />
+      <FolderIcon className={iconClass} size={16} />
     );
   }
 
   const ext = filename ? getFileExtension(filename) : "";
-  const IconComponent = FILE_ICON_MAP[ext] || File;
+  const IconComponent = FILE_ICON_MAP[ext] || FileIconSymbol;
 
   return <IconComponent className={iconClass} size={16} />;
 }
@@ -434,7 +434,7 @@ function NodeRenderer({
             animate={{ rotate: node.isOpen ? 90 : 0 }}
             transition={{ duration: 0.15, ease: "easeOut" }}
           >
-            <CaretRight className="w-3 h-3" weight="fill" />
+            <CaretRightIcon className="w-3 h-3" weight="fill" />
           </motion.div>
         )}
         {!isDirectory && <span className="w-3" />}
@@ -664,13 +664,13 @@ export const FileTree = memo(function FileTree({
           label: "New File",
           onClick: () =>
             setDialog({ type: "create-file", parentPath: node.path }),
-          icon: <FilePlus size={16} />,
+          icon: <FilePlusIcon size={16} />,
         });
         items.push({
           label: "New Folder",
           onClick: () =>
             setDialog({ type: "create-directory", parentPath: node.path }),
-          icon: <FolderPlus size={16} />,
+          icon: <FolderPlusIcon size={16} />,
         });
       }
 
@@ -693,7 +693,7 @@ export const FileTree = memo(function FileTree({
       items.push({
         label: "Rename",
         onClick: () => setDialog({ type: "rename", node }),
-        icon: <PencilLine size={16} />,
+        icon: <PencilLineIcon size={16} />,
       });
 
       // Duplicate (for files only)
@@ -750,7 +750,7 @@ export const FileTree = memo(function FileTree({
           }
         },
         danger: true,
-        icon: <Trash size={16} />,
+        icon: <TrashIcon size={16} />,
       });
 
       // --- External actions ---
@@ -772,7 +772,7 @@ export const FileTree = memo(function FileTree({
               console.error("Failed to reveal in file manager:", error);
             }
           },
-          icon: <ArrowSquareOut size={16} />,
+          icon: <ArrowSquareOutIcon size={16} />,
         });
 
         // Open in Terminal (for directories)
@@ -796,7 +796,7 @@ export const FileTree = memo(function FileTree({
         items.push({
           label: "Refresh",
           onClick: onRefresh,
-          icon: <ArrowClockwise size={16} />,
+          icon: <ArrowClockwiseIcon size={16} />,
         });
       }
 
@@ -813,12 +813,12 @@ export const FileTree = memo(function FileTree({
       items.push({
         label: "New File",
         onClick: () => setDialog({ type: "create-file", parentPath: "" }),
-        icon: <FilePlus size={16} />,
+        icon: <FilePlusIcon size={16} />,
       });
       items.push({
         label: "New Folder",
         onClick: () => setDialog({ type: "create-directory", parentPath: "" }),
-        icon: <FolderPlus size={16} />,
+        icon: <FolderPlusIcon size={16} />,
       });
     }
 
@@ -845,7 +845,7 @@ export const FileTree = memo(function FileTree({
             console.error("Failed to reveal in file manager:", error);
           }
         },
-        icon: <ArrowSquareOut size={16} />,
+        icon: <ArrowSquareOutIcon size={16} />,
       });
 
       items.push({
@@ -865,7 +865,7 @@ export const FileTree = memo(function FileTree({
       items.push({
         label: "Refresh",
         onClick: onRefresh,
-        icon: <ArrowClockwise size={16} />,
+        icon: <ArrowClockwiseIcon size={16} />,
       });
     }
 

--- a/apps/desktop/src/components/editor/inline-diff-review.tsx
+++ b/apps/desktop/src/components/editor/inline-diff-review.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, memo } from "react";
 import dynamic from "next/dynamic";
 import type { PendingEdit } from "@/lib/opencode/types";
-import { PencilSimple } from "@phosphor-icons/react";
+import { PencilSimpleIcon } from "@phosphor-icons/react";
 
 const MonacoDiffEditor = dynamic(
   () =>
@@ -81,7 +81,7 @@ export const InlineDiffReview = memo(function InlineDiffReview({
       <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-200 bg-amber-50">
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <PencilSimple className="w-4 h-4 text-amber-600" />
+            <PencilSimpleIcon className="w-4 h-4 text-amber-600" />
             <span className="text-sm font-medium text-amber-800">
               Review AI Changes
             </span>

--- a/apps/desktop/src/components/latex/latex-install-prompt.tsx
+++ b/apps/desktop/src/components/latex/latex-install-prompt.tsx
@@ -4,7 +4,7 @@ import { useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useLatexInstaller } from "@/lib/latex";
 import { Spinner } from "@/components/ui/spinner";
-import { ArrowClockwise, Warning } from "@phosphor-icons/react";
+import { ArrowClockwiseIcon, WarningIcon } from "@phosphor-icons/react";
 
 interface LaTeXInstallPromptProps {
   onRefreshCompilers?: () => void;
@@ -43,7 +43,7 @@ export function LaTeXInstallPrompt({ onRefreshCompilers }: LaTeXInstallPromptPro
     <div className="bg-amber-50 border-2 border-amber-400 p-4">
       <div className="flex items-start gap-3">
         {/* Warning Icon */}
-        <Warning className="size-6 text-amber-600 flex-shrink-0 mt-0.5" />
+        <WarningIcon className="size-6 text-amber-600 flex-shrink-0 mt-0.5" />
 
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-2">
@@ -59,7 +59,7 @@ export function LaTeXInstallPrompt({ onRefreshCompilers }: LaTeXInstallPromptPro
                 className="flex-shrink-0 p-1.5 text-amber-600 hover:text-amber-800 hover:bg-amber-100 rounded transition-colors"
                 title="Refresh compiler detection"
               >
-                <ArrowClockwise className="size-4" />
+                <ArrowClockwiseIcon className="size-4" />
               </button>
             )}
           </div>

--- a/apps/desktop/src/components/latex/latex-settings-dialog.tsx
+++ b/apps/desktop/src/components/latex/latex-settings-dialog.tsx
@@ -3,11 +3,11 @@
 import { useCallback, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
-  ArrowCounterClockwise,
-  Check,
-  Minus,
-  Plus,
-  X,
+  ArrowCounterClockwiseIcon,
+  CheckIcon,
+  MinusIcon,
+  PlusIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import {
   LaTeXSettings,
@@ -62,7 +62,7 @@ function CheckboxItem({
             : "border-neutral-300 group-hover:border-black"
         }`}
       >
-        {checked && <Check className="size-3 text-white" weight="bold" />}
+        {checked && <CheckIcon className="size-3 text-white" weight="bold" />}
       </div>
       <input
         type="checkbox"
@@ -187,7 +187,7 @@ export function LaTeXSettingsDialog({
                   className="p-1.5 hover:bg-neutral-100 transition-colors border border-transparent hover:border-neutral-200"
                   aria-label="Close"
                 >
-                  <X className="size-4" />
+                  <XIcon className="size-4" />
                 </button>
               </div>
 
@@ -276,7 +276,7 @@ export function LaTeXSettingsDialog({
                                 </span>
                               </div>
                               {isSelected && (
-                                <Check className="size-4 flex-shrink-0 text-black" />
+                                <CheckIcon className="size-4 flex-shrink-0 text-black" />
                               )}
                             </button>
                           );
@@ -303,7 +303,7 @@ export function LaTeXSettingsDialog({
                           className="w-8 h-8 flex items-center justify-center text-neutral-500 hover:text-black hover:bg-neutral-100 transition-colors border-r border-neutral-200"
                           aria-label="Decrease font size"
                         >
-                          <Minus className="size-3" />
+                          <MinusIcon className="size-3" />
                         </button>
                         <input
                           type="number"
@@ -332,7 +332,7 @@ export function LaTeXSettingsDialog({
                           className="w-8 h-8 flex items-center justify-center text-neutral-500 hover:text-black hover:bg-neutral-100 transition-colors border-l border-neutral-200"
                           aria-label="Increase font size"
                         >
-                          <Plus className="size-3" />
+                          <PlusIcon className="size-3" />
                         </button>
                         <span className="text-xs text-neutral-400 px-2 border-l border-neutral-200">
                           px
@@ -359,7 +359,7 @@ export function LaTeXSettingsDialog({
                           className="w-8 h-8 flex items-center justify-center text-neutral-500 hover:text-black hover:bg-neutral-100 transition-colors border-r border-neutral-200"
                           aria-label="Decrease line height"
                         >
-                          <Minus className="size-3" />
+                          <MinusIcon className="size-3" />
                         </button>
                         <input
                           type="number"
@@ -394,7 +394,7 @@ export function LaTeXSettingsDialog({
                           className="w-8 h-8 flex items-center justify-center text-neutral-500 hover:text-black hover:bg-neutral-100 transition-colors border-l border-neutral-200"
                           aria-label="Increase line height"
                         >
-                          <Plus className="size-3" />
+                          <PlusIcon className="size-3" />
                         </button>
                       </div>
                     </div>
@@ -805,7 +805,7 @@ export function LaTeXSettingsDialog({
                   }
                   className="text-xs text-neutral-500 hover:text-black transition-colors flex items-center gap-1.5 group"
                 >
-                  <ArrowCounterClockwise className="size-3.5 group-hover:rotate-[-45deg] transition-transform" />
+                  <ArrowCounterClockwiseIcon className="size-3.5 group-hover:rotate-[-45deg] transition-transform" />
                   Reset to Defaults
                 </button>
                 <button

--- a/apps/desktop/src/components/latex/main-file-selection-dialog.tsx
+++ b/apps/desktop/src/components/latex/main-file-selection-dialog.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { pathSync } from "@/lib/path";
 import type { MainFileDetectionResult } from "@/lib/latex/types";
-import { Check, FileText } from "@phosphor-icons/react";
+import { CheckIcon, FileTextIcon } from "@phosphor-icons/react";
 
 interface MainFileSelectionDialogProps {
   open: boolean;
@@ -101,7 +101,7 @@ export function MainFileSelectionDialog({
                       }`}
                     >
                       <div className="flex items-center gap-2 min-w-0">
-                        <FileText
+                        <FileTextIcon
                           className={`size-4 flex-shrink-0 ${isSelected ? "text-white" : "text-neutral-400"}`}
                         />
                         <span className="truncate font-medium">{fileName}</span>
@@ -114,7 +114,7 @@ export function MainFileSelectionDialog({
                             Recommended
                           </span>
                         )}
-                        {isSelected && <Check className="size-4" />}
+                        {isSelected && <CheckIcon className="size-4" />}
                       </div>
                     </button>
                   );

--- a/apps/desktop/src/components/motion.tsx
+++ b/apps/desktop/src/components/motion.tsx
@@ -7,7 +7,7 @@ import {
   type HTMLMotionProps,
 } from "framer-motion";
 import { forwardRef, type ReactNode } from "react";
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 
 const GPU_SPRING = {
   type: "spring",
@@ -181,7 +181,7 @@ export function MotionChevron({ expanded }: { expanded: boolean }) {
       }
       style={prefersReducedMotion ? undefined : { willChange: "transform" }}
     >
-      <CaretRight className="w-3 h-3" weight="fill" />
+      <CaretRightIcon className="w-3 h-3" weight="fill" />
     </motion.div>
   );
 }

--- a/apps/desktop/src/components/opencode/icons.tsx
+++ b/apps/desktop/src/components/opencode/icons.tsx
@@ -1,31 +1,31 @@
 import {
-  Archive,
-  BookOpenText,
-  CaretDown,
-  CaretRight,
-  Check,
-  File,
-  FilePlus,
-  FileText,
-  Folder,
-  FolderOpen,
-  Gear,
-  Globe,
-  Image,
-  ListChecks,
-  Monitor,
-  NotePencil,
-  PaperPlaneRight,
-  Plug,
-  Plus,
-  Question,
-  Robot,
-  StarFour,
-  Stop,
-  Terminal,
-  TextT,
-  Trash,
-  Warning,
+  ArchiveIcon,
+  BookOpenTextIcon,
+  CaretDownIcon,
+  CaretRightIcon,
+  CheckIcon as PhosphorCheckIcon,
+  FileIcon,
+  FilePlusIcon,
+  FileTextIcon,
+  FolderIcon as PhosphorFolderIcon,
+  FolderOpenIcon,
+  GearIcon,
+  GlobeIcon,
+  ImageIcon as PhosphorImageIcon,
+  ListChecksIcon,
+  MonitorIcon,
+  NotePencilIcon,
+  PaperPlaneRightIcon,
+  PlugIcon,
+  PlusIcon as PhosphorPlusIcon,
+  QuestionIcon,
+  RobotIcon,
+  StarFourIcon,
+  StopIcon as PhosphorStopIcon,
+  TerminalIcon as PhosphorTerminalIcon,
+  TextTIcon,
+  TrashIcon as PhosphorTrashIcon,
+  WarningIcon as PhosphorWarningIcon,
 } from "@phosphor-icons/react";
 
 export function ProviderIcon({ providerId }: { providerId?: string }) {
@@ -58,7 +58,7 @@ export function ProviderIcon({ providerId }: { providerId?: string }) {
     );
   }
 
-  return <Monitor className={iconClass} />;
+  return <MonitorIcon className={iconClass} />;
 }
 
 export function ToolIcon({ tool }: { tool: string }) {
@@ -68,34 +68,34 @@ export function ToolIcon({ tool }: { tool: string }) {
   switch (toolLower) {
     // Terminal/Shell operations
     case "bash":
-      return <Terminal className={`${baseClassName} text-emerald-600`} />;
+      return <PhosphorTerminalIcon className={`${baseClassName} text-emerald-600`} />;
 
     // File reading - eye/book icon in blue
     case "read":
-      return <BookOpenText className={`${baseClassName} text-sky-500`} />;
+      return <BookOpenTextIcon className={`${baseClassName} text-sky-500`} />;
 
     // File writing - file plus icon in green
     case "write":
-      return <FilePlus className={`${baseClassName} text-green-500`} />;
+      return <FilePlusIcon className={`${baseClassName} text-green-500`} />;
 
     // File editing - pencil icon in amber
     case "edit":
-      return <NotePencil className={`${baseClassName} text-amber-500`} />;
+      return <NotePencilIcon className={`${baseClassName} text-amber-500`} />;
 
     // Search operations
     case "glob":
-      return <FolderOpen className={`${baseClassName} text-violet-500`} />;
+      return <FolderOpenIcon className={`${baseClassName} text-violet-500`} />;
     case "grep":
-      return <TextT className={`${baseClassName} text-violet-500`} />;
+      return <TextTIcon className={`${baseClassName} text-violet-500`} />;
 
     // Web operations
     case "webfetch":
     case "websearch":
-      return <Globe className={`${baseClassName} text-blue-500`} />;
+      return <GlobeIcon className={`${baseClassName} text-blue-500`} />;
 
     // Agent/Task operations
     case "task":
-      return <Robot className={`${baseClassName} text-purple-500`} />;
+      return <RobotIcon className={`${baseClassName} text-purple-500`} />;
 
     // Todo/Task list operations
     case "todowrite":
@@ -103,72 +103,72 @@ export function ToolIcon({ tool }: { tool: string }) {
     case "todoread":
     case "todolist":
     case "todoupdate":
-      return <ListChecks className={`${baseClassName} text-teal-500`} />;
+      return <ListChecksIcon className={`${baseClassName} text-teal-500`} />;
 
     // MCP/Plugin operations
     case "mcp":
-      return <Plug className={`${baseClassName} text-orange-500`} />;
+      return <PlugIcon className={`${baseClassName} text-orange-500`} />;
 
     // Question/User input
     case "question":
     case "askuserquestion":
-      return <Question className={`${baseClassName} text-pink-500`} />;
+      return <QuestionIcon className={`${baseClassName} text-pink-500`} />;
 
     // List directory
     case "list":
-      return <Folder className={`${baseClassName} text-yellow-600`} />;
+      return <PhosphorFolderIcon className={`${baseClassName} text-yellow-600`} />;
 
     default:
-      return <StarFour className={`${baseClassName} text-neutral-400`} />;
+      return <StarFourIcon className={`${baseClassName} text-neutral-400`} />;
   }
 }
 
 export function ChevronIcon({ className }: { className?: string }) {
-  return <CaretDown className={className} />;
+  return <CaretDownIcon className={className} />;
 }
 
 export function ChevronRightIcon({ className }: { className?: string }) {
-  return <CaretRight className={className} />;
+  return <CaretRightIcon className={className} />;
 }
 
 export function WarningIcon({ className }: { className?: string }) {
-  return <Warning className={className} />;
+  return <PhosphorWarningIcon className={className} />;
 }
 
 export function TrashIcon({ className }: { className?: string }) {
-  return <Trash className={className} />;
+  return <PhosphorTrashIcon className={className} />;
 }
 
 export function PlusIcon({ className }: { className?: string }) {
-  return <Plus className={className} />;
+  return <PhosphorPlusIcon className={className} />;
 }
 
 export function CheckIcon({ className }: { className?: string }) {
-  return <Check className={className} weight="bold" />;
+  return <PhosphorCheckIcon className={className} weight="bold" />;
 }
 
 export function FolderIcon({ className }: { className?: string }) {
-  return <Folder className={className} />;
+  return <PhosphorFolderIcon className={className} />;
 }
 
 export function TerminalIcon({ className }: { className?: string }) {
-  return <Terminal className={className} />;
+  return <PhosphorTerminalIcon className={className} />;
 }
 
 export function SendIcon({ className }: { className?: string }) {
-  return <PaperPlaneRight className={className} />;
+  return <PaperPlaneRightIcon className={className} />;
 }
 
 export function ImageIcon({ className }: { className?: string }) {
-  return <Image className={className} />;
+  return <PhosphorImageIcon className={className} />;
 }
 
 export function StopIcon({ className }: { className?: string }) {
-  return <Stop className={className} />;
+  return <PhosphorStopIcon className={className} />;
 }
 
 export function SettingsIcon({ className }: { className?: string }) {
-  return <Gear className={className} />;
+  return <GearIcon className={className} />;
 }
 
 export function DisclosureTriangle({
@@ -179,7 +179,7 @@ export function DisclosureTriangle({
   className?: string;
 }) {
   return (
-    <CaretRight
+    <CaretRightIcon
       className={`size-3 transition-transform ${open ? "rotate-90" : ""} ${className || ""}`}
       weight="fill"
     />
@@ -192,74 +192,74 @@ export function FileTypeIcon({ filename }: { filename: string }) {
 
   // PDF files - red
   if (ext === "pdf") {
-    return <File className={`${className} text-red-500`} />;
+    return <FileIcon className={`${className} text-red-500`} />;
   }
 
   // Log and auxiliary files - gray
   if (ext === "log" || ext === "aux" || ext === "fdb_latexmk") {
-    return <FileText className={`${className} text-neutral-400`} />;
+    return <FileTextIcon className={`${className} text-neutral-400`} />;
   }
 
   // LaTeX files - teal
   if (ext === "tex" || ext === "bib" || ext === "cls" || ext === "sty") {
-    return <FileText className={`${className} text-teal-600`} />;
+    return <FileTextIcon className={`${className} text-teal-600`} />;
   }
 
   // Archive files - amber
   if (ext === "gz" || ext === "synctex" || ext === "xdv" || ext === "zip" || ext === "tar") {
-    return <Archive className={`${className} text-amber-500`} />;
+    return <ArchiveIcon className={`${className} text-amber-500`} />;
   }
 
   // TypeScript/JavaScript files - blue/yellow
   if (ext === "ts" || ext === "tsx") {
-    return <FileText className={`${className} text-blue-500`} />;
+    return <FileTextIcon className={`${className} text-blue-500`} />;
   }
   if (ext === "js" || ext === "jsx" || ext === "mjs") {
-    return <FileText className={`${className} text-yellow-500`} />;
+    return <FileTextIcon className={`${className} text-yellow-500`} />;
   }
 
   // Python files - green
   if (ext === "py" || ext === "pyw" || ext === "pyi") {
-    return <FileText className={`${className} text-green-500`} />;
+    return <FileTextIcon className={`${className} text-green-500`} />;
   }
 
   // Rust files - orange
   if (ext === "rs") {
-    return <FileText className={`${className} text-orange-500`} />;
+    return <FileTextIcon className={`${className} text-orange-500`} />;
   }
 
   // Go files - cyan
   if (ext === "go") {
-    return <FileText className={`${className} text-cyan-500`} />;
+    return <FileTextIcon className={`${className} text-cyan-500`} />;
   }
 
   // HTML/CSS files - orange/pink
   if (ext === "html" || ext === "htm") {
-    return <FileText className={`${className} text-orange-600`} />;
+    return <FileTextIcon className={`${className} text-orange-600`} />;
   }
   if (ext === "css" || ext === "scss" || ext === "sass" || ext === "less") {
-    return <FileText className={`${className} text-pink-500`} />;
+    return <FileTextIcon className={`${className} text-pink-500`} />;
   }
 
   // Config files - purple
   if (ext === "json" || ext === "yaml" || ext === "yml" || ext === "toml") {
-    return <FileText className={`${className} text-violet-500`} />;
+    return <FileTextIcon className={`${className} text-violet-500`} />;
   }
 
   // Markdown files - indigo
   if (ext === "md" || ext === "mdx") {
-    return <FileText className={`${className} text-indigo-500`} />;
+    return <FileTextIcon className={`${className} text-indigo-500`} />;
   }
 
   // Shell scripts - emerald
   if (ext === "sh" || ext === "bash" || ext === "zsh") {
-    return <FileText className={`${className} text-emerald-500`} />;
+    return <FileTextIcon className={`${className} text-emerald-500`} />;
   }
 
   // Image files - rose
   if (ext === "png" || ext === "jpg" || ext === "jpeg" || ext === "gif" || ext === "svg" || ext === "webp") {
-    return <Image className={`${className} text-rose-500`} />;
+    return <PhosphorImageIcon className={`${className} text-rose-500`} />;
   }
 
-  return <File className={`${className} text-neutral-500`} />;
+  return <FileIcon className={`${className} text-neutral-500`} />;
 }

--- a/apps/desktop/src/components/opencode/input-area.tsx
+++ b/apps/desktop/src/components/opencode/input-area.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
-import { CaretLeft, CaretRight, X } from "@phosphor-icons/react";
+import { CaretLeftIcon, CaretRightIcon, XIcon } from "@phosphor-icons/react";
 import { ChevronIcon, ImageIcon, SendIcon, StopIcon } from "./icons";
 import type { AttachedFile } from "./types";
 
@@ -192,7 +192,7 @@ export function InputArea({
                   className="absolute -top-1.5 -right-1.5 size-5 bg-black text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
                   title="Remove"
                 >
-                  <X className="size-3" />
+                  <XIcon className="size-3" />
                 </button>
               </div>
             ))}
@@ -331,7 +331,7 @@ export function InputArea({
                 className="absolute top-2 right-2 size-8 bg-black/50 hover:bg-black/70 text-white rounded-full flex items-center justify-center transition-colors"
                 title="Close"
               >
-                <X className="size-5" />
+                <XIcon className="size-5" />
               </button>
               {/* Navigation arrows */}
               {attachedFiles.length > 1 && (
@@ -344,7 +344,7 @@ export function InputArea({
                     className="absolute left-2 top-1/2 -translate-y-1/2 size-10 bg-black/50 hover:bg-black/70 text-white rounded-full flex items-center justify-center transition-colors"
                     title="Previous"
                   >
-                    <CaretLeft className="size-6" />
+                    <CaretLeftIcon className="size-6" />
                   </button>
                   <button
                     onClick={(e) => {
@@ -354,7 +354,7 @@ export function InputArea({
                     className="absolute right-2 top-1/2 -translate-y-1/2 size-10 bg-black/50 hover:bg-black/70 text-white rounded-full flex items-center justify-center transition-colors"
                     title="Next"
                   >
-                    <CaretRight className="size-6" />
+                    <CaretRightIcon className="size-6" />
                   </button>
                 </>
               )}

--- a/apps/desktop/src/components/opencode/opencode-disconnected-dialog.tsx
+++ b/apps/desktop/src/components/opencode/opencode-disconnected-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { Warning, X } from "@phosphor-icons/react";
+import { WarningIcon, XIcon } from "@phosphor-icons/react";
 
 type Props = {
   open: boolean;
@@ -89,14 +89,14 @@ export function OpenCodeDisconnectedDialog({
             className="p-1 text-muted hover:text-black transition-colors"
             aria-label="Close dialog"
           >
-            <X className="size-4" />
+            <XIcon className="size-4" />
           </button>
         </div>
 
         <div className="px-4 py-4">
           <div className="flex items-start gap-3">
             <div className="flex-shrink-0 mt-0.5">
-              <Warning className="size-5 text-muted" />
+              <WarningIcon className="size-5 text-muted" />
             </div>
             <div className="flex-1">
               <p className="text-sm text-foreground">

--- a/apps/desktop/src/components/opencode/opencode-error-boundary.tsx
+++ b/apps/desktop/src/components/opencode/opencode-error-boundary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Component, ErrorInfo, ReactNode } from "react";
-import { Warning } from "@phosphor-icons/react";
+import { WarningIcon } from "@phosphor-icons/react";
 
 type Props = {
   children: ReactNode;
@@ -37,7 +37,7 @@ export class OpenCodeErrorBoundary extends Component<Props, State> {
       return (
         <div className="h-full flex flex-col items-center justify-center p-6 text-center">
           <div className="size-12 border border-neutral-300 flex items-center justify-center mb-4">
-            <Warning className="size-6 text-neutral-400" />
+            <WarningIcon className="size-6 text-neutral-400" />
           </div>
           <h3 className="text-sm font-medium text-neutral-900 mb-1">
             OpenCode Panel Error

--- a/apps/desktop/src/components/opencode/opencode-error-dialog.tsx
+++ b/apps/desktop/src/components/opencode/opencode-error-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
-import { Warning, X } from "@phosphor-icons/react";
+import { WarningIcon, XIcon } from "@phosphor-icons/react";
 
 type ErrorType = "port_in_use" | "not_installed" | "generic";
 
@@ -127,14 +127,14 @@ export function OpenCodeErrorDialog({
             className="p-1 text-muted hover:text-black transition-colors"
             aria-label="Close dialog"
           >
-            <X className="size-4" />
+            <XIcon className="size-4" />
           </button>
         </div>
 
         <div className="px-4 py-4">
           <div className="flex items-start gap-3">
             <div className="flex-shrink-0 mt-0.5">
-              <Warning className="size-5 text-red-500" />
+              <WarningIcon className="size-5 text-red-500" />
             </div>
             <div className="flex-1 min-w-0">
               {errorType === "port_in_use" && (

--- a/apps/desktop/src/components/recent-projects.tsx
+++ b/apps/desktop/src/components/recent-projects.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Folder, Trash } from "@phosphor-icons/react";
+import { FolderIcon, TrashIcon } from "@phosphor-icons/react";
 import type { RecentProject } from "@/lib/recent-projects";
 import { formatRelativeTime } from "./opencode/utils";
 
@@ -48,7 +48,7 @@ export function RecentProjects({
                 onClick={() => onSelect(project.path)}
                 className="flex-1 text-left px-3 py-2.5 flex items-center gap-3 min-w-0"
               >
-                <Folder className="size-4 text-muted flex-shrink-0" />
+                <FolderIcon className="size-4 text-muted flex-shrink-0" />
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium truncate">{project.name}</p>
                   <p className="text-xs text-muted truncate">{project.path}</p>
@@ -65,7 +65,7 @@ export function RecentProjects({
                 className="px-3 py-2 text-muted hover:text-red-600 transition-colors"
                 title="Remove from history"
               >
-                <Trash className="size-4" />
+                <TrashIcon className="size-4" />
               </button>
             </div>
           );

--- a/apps/desktop/src/components/ui/spinner.tsx
+++ b/apps/desktop/src/components/ui/spinner.tsx
@@ -1,5 +1,5 @@
-import { CircleNotch } from "@phosphor-icons/react";
+import { CircleNotchIcon } from "@phosphor-icons/react";
 
 export function Spinner({ className = "size-4" }: { className?: string }) {
-  return <CircleNotch className={`animate-spin ${className}`} />;
+  return <CircleNotchIcon className={`animate-spin ${className}`} />;
 }

--- a/apps/desktop/src/components/ui/toast.tsx
+++ b/apps/desktop/src/components/ui/toast.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Check, Info, X } from "@phosphor-icons/react";
+import { CheckIcon, InfoIcon, XIcon } from "@phosphor-icons/react";
 
 type ToastType = "success" | "error" | "info";
 
@@ -82,7 +82,7 @@ function ToastItem({
           className="flex-shrink-0 text-black hover:opacity-60 transition-opacity"
           aria-label="Dismiss"
         >
-          <X className="w-3.5 h-3.5" />
+          <XIcon className="w-3.5 h-3.5" />
         </button>
       </div>
     </motion.div>
@@ -92,11 +92,11 @@ function ToastItem({
 function getIcon(type: ToastType) {
   switch (type) {
     case "success":
-      return <Check size={18} className="text-black" />;
+      return <CheckIcon size={18} className="text-black" />;
     case "error":
-      return <X size={18} className="text-black" />;
+      return <XIcon size={18} className="text-black" />;
     case "info":
-      return <Info size={18} className="text-black" />;
+      return <InfoIcon size={18} className="text-black" />;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Phosphor Icons v2.1.8 introduced Icon-suffixed component names (e.g. `XIcon`, `CaretRightIcon`) and the codebase must be updated to match the new exports to avoid runtime/compile errors.
- Align desktop app components and shared icon wrappers to the new naming so imports and usages remain consistent across the UI.

### Description
- Replaced Phosphor imports/usages across the desktop app to use Icon-suffixed names and adjusted local aliases where needed (examples: `X` → `XIcon`, `CaretRight` → `CaretRightIcon`, `File` → `FileIcon`, `Check` → `CheckIcon`).
- Updated the opencode icon wrapper and file-type/icon maps to return the new Icon components (`apps/desktop/src/components/opencode/icons.tsx`, `apps/desktop/src/components/editor/file-tree.tsx`).
- Updated individual components that referenced Phosphor icons: `app/page.tsx`, `auth/*` (`login-code-modal.tsx`, `user-dropdown.tsx`), `editor/*` (file-tree, changes-review-panel, inline-diff-review, editor-error-boundary), `latex/*` (install-prompt, settings-dialog, main-file-selection-dialog), `opencode/*` (input-area, error-dialog, disconnected-dialog, error-boundary), `recent-projects.tsx`, `ui/*` (spinner.tsx, toast.tsx), `motion.tsx`, and others.
- All changes were committed with message: "Update Phosphor icon imports" and touch ~19 files updating ~300 lines total.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849147c774832bbbfda4fa36c7647e)