### PR TITLE
chore: remove noisy debug logs across desktop and web

### DIFF
--- a/apps/desktop/src/components/opencode/opencode-panel.tsx
+++ b/apps/desktop/src/components/opencode/opencode-panel.tsx
@@ -163,11 +163,8 @@ export const OpenCodePanel = memo(function OpenCodePanel({
       if (turnCompleteTimeoutRef.current) {
         clearTimeout(turnCompleteTimeoutRef.current);
       }
-
-      console.log(`[Review] Scheduling onTurnComplete (${reason}) in 800ms`);
       // Wait briefly to ensure async capture/read operations have settled.
       turnCompleteTimeoutRef.current = setTimeout(() => {
-        console.log("[Review] Triggering onTurnComplete callback");
         onTurnComplete();
         hasCompletedFileEditRef.current = false;
         turnCompleteTimeoutRef.current = null;
@@ -203,13 +200,6 @@ export const OpenCodePanel = memo(function OpenCodePanel({
         const toolKey = `${toolName}:${toolPart.state.status}`;
         if (REVIEW_DEBUG && !seenToolKindsRef.current.has(toolKey)) {
           seenToolKindsRef.current.add(toolKey);
-          console.log("[Review][ToolSeen]", {
-            tool: toolName,
-            status: toolPart.state.status,
-            isFileTool,
-            filePath,
-            inputKeys: Object.keys(input),
-          });
         }
 
         if (!isFileTool) return;
@@ -218,13 +208,11 @@ export const OpenCodePanel = memo(function OpenCodePanel({
         const messageId = toolPart.messageID;
 
         if (!filePath) {
-          console.log("[Review] File-write tool missing file path:", toolName, input);
           return;
         }
 
         // When tool starts running, capture the file content
         if (toolPart.state.status === "running" && !runningToolsRef.current.has(toolId)) {
-          console.log("[Review] Capturing file content before edit:", filePath);
           runningToolsRef.current.set(toolId, filePath);
           onCaptureFileContent?.(toolId, filePath);
         }
@@ -236,12 +224,7 @@ export const OpenCodePanel = memo(function OpenCodePanel({
           !processedToolsRef.current.has(toolId)
         ) {
           if (!runningToolsRef.current.has(toolId)) {
-            console.log(
-              "[Review] Tool completed without prior running state, using fallback path:",
-              filePath,
-            );
           }
-          console.log("[Review] Tool completed, creating pending edit:", filePath);
           processedToolsRef.current.add(toolId);
           runningToolsRef.current.delete(toolId);
           hasCompletedFileEditRef.current = true;
@@ -272,8 +255,6 @@ export const OpenCodePanel = memo(function OpenCodePanel({
     const prevStatus = previousStatusRef.current;
     const currentStatus = opencode.status.type;
 
-    console.log("[Review] Status change:", prevStatus, "->", currentStatus);
-
     const previousWasActive =
       prevStatus === "running" || prevStatus === "busy" || prevStatus === "retry";
     if (
@@ -288,14 +269,6 @@ export const OpenCodePanel = memo(function OpenCodePanel({
 
   useEffect(() => {
     if (!REVIEW_DEBUG) return;
-    console.log("[Review][PanelState]", {
-      status: opencode.status.type,
-      pendingEditCount,
-      hasCompletedFileEdit: hasCompletedFileEditRef.current,
-      processedTools: processedToolsRef.current.size,
-      runningTools: runningToolsRef.current.size,
-      partGroups: opencode.parts.size,
-    });
   }, [opencode.status.type, pendingEditCount, opencode.parts]);
 
   // Handle pending message from external source

--- a/apps/desktop/src/lib/auth/use-auth.ts
+++ b/apps/desktop/src/lib/auth/use-auth.ts
@@ -268,7 +268,6 @@ export function useAuth() {
 
       // First try getSession which checks stored session
       const { data: { session } } = await supabase.auth.getSession();
-      console.log("[useAuth] refreshAuth - getSession result:", { hasSession: !!session });
 
       if (session) {
         const profile = await fetchProfile(session);
@@ -282,12 +281,7 @@ export function useAuth() {
         });
         return;
       }
-
-      // If no stored session, try to get user from any cached access token
-      // This handles the case where setSession failed but the access token is valid
-      console.log("[useAuth] No stored session, trying getUser...");
       const { data: { user }, error: userError } = await supabase.auth.getUser();
-      console.log("[useAuth] getUser result:", { hasUser: !!user, error: userError?.message });
 
       if (user && !userError) {
         // We have a valid user but no proper session
@@ -331,12 +325,10 @@ export function useAuth() {
   // Set auth state using an access token directly (used when setSession fails)
   const setAuthWithToken = useCallback(async (accessToken: string) => {
     try {
-      console.log("[useAuth] setAuthWithToken called");
       const supabase = getSupabaseClient();
 
       // Validate the access token and get user data
       const { data: { user }, error: userError } = await supabase.auth.getUser(accessToken);
-      console.log("[useAuth] getUser with token result:", { hasUser: !!user, error: userError?.message });
 
       if (userError || !user) {
         console.error("[useAuth] Token validation failed:", userError?.message);
@@ -362,8 +354,6 @@ export function useAuth() {
         error: null,
         isConfigured: true,
       });
-
-      console.log("[useAuth] Auth state set successfully with token");
       return true;
     } catch (err) {
       console.error("[useAuth] setAuthWithToken error:", err);

--- a/apps/web/src/app/api/refresh-stars/route.ts
+++ b/apps/web/src/app/api/refresh-stars/route.ts
@@ -29,25 +29,15 @@ export async function POST() {
   }
 
   try {
-    console.log("[refresh-stars] Checking starred repos...");
     const { allStarred, eligibleCount } = await checkStarredRepos(
       tokenInfo.accessToken,
     );
-    console.log(
-      "[refresh-stars] Found starred repos:",
-      allStarred.length,
-      "eligible:",
-      eligibleCount,
-    );
-
-    console.log("[refresh-stars] Updating membership...");
     const result = await updateMembershipFromStars(
       supabase,
       user.id,
       allStarred,
       eligibleCount,
     );
-    console.log("[refresh-stars] Update result:", result);
 
     if (result.error) {
       console.error("[refresh-stars] Membership update error:", result.error);

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -3,33 +3,22 @@ import { NextResponse } from "next/server";
 import { getGitHubUser, storeGitHubToken } from "@/lib/github/stars";
 
 export async function GET(request: Request) {
-  console.log("=== [auth/callback] Callback Route Hit ===");
 
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   const error_param = searchParams.get("error");
   const error_description = searchParams.get("error_description");
 
-  console.log("[auth/callback] Full URL:", request.url);
-  console.log("[auth/callback] Origin:", origin);
-  console.log("[auth/callback] Code exists:", !!code);
-  console.log("[auth/callback] Error param:", error_param);
-
   // Check source from URL first, then from cookie as backup
   let source: string | null = searchParams.get("source");
-  console.log("[auth/callback] Source from URL:", source);
 
   if (!source) {
     const cookieHeader = request.headers.get("cookie") || "";
-    console.log("[auth/callback] Cookies:", cookieHeader);
     const authSourceMatch = cookieHeader.match(/auth_source=([^;]+)/);
     if (authSourceMatch) {
       source = authSourceMatch[1] ?? null;
-      console.log("[auth/callback] Source from cookie:", source);
     }
   }
-
-  console.log("[auth/callback] Final source:", source);
 
   if (error_param) {
     const errorMsg = encodeURIComponent(error_description || error_param);
@@ -51,9 +40,6 @@ export async function GET(request: Request) {
     }
 
     const session = data.session;
-    console.log("[auth/callback] session exists:", !!session);
-    console.log("[auth/callback] access_token length:", session?.access_token?.length);
-    console.log("[auth/callback] refresh_token length:", session?.refresh_token?.length);
 
     // Store GitHub token if available
     if (session?.provider_token && session.user) {
@@ -70,8 +56,6 @@ export async function GET(request: Request) {
         // Silently fail - not critical
       }
     }
-
-    console.log("[auth/callback] Web flow - redirecting to post-login");
     return NextResponse.redirect(`${origin}/auth/post-login`);
   }
 

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -15,9 +15,6 @@ export function LoginForm() {
   // Get appropriate Supabase client based on flow
   const getSupabaseClient = () => {
     if (source === "desktop") {
-      // Use standard client with PKCE flow for desktop
-      // Explicitly set storage to window.localStorage
-      console.log("[LoginForm] Creating standard client with PKCE flow");
       return createStandardClient(
         process.env.NEXT_PUBLIC_SUPABASE_URL!,
         process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -38,13 +35,8 @@ export function LoginForm() {
     setLoading(true);
     setError(null);
 
-    console.log("=== [LoginForm] GitHub Login Started ===");
-    console.log("[LoginForm] Current URL:", window.location.href);
-    console.log("[LoginForm] source param:", source);
-
     try {
       const supabase = getSupabaseClient();
-      console.log("[LoginForm] Using", source === "desktop" ? "standard" : "SSR", "client");
 
       // Preserve source parameter (e.g., desktop) through OAuth flow
       if (source === "desktop") {
@@ -53,13 +45,10 @@ export function LoginForm() {
         const callbackPort = searchParams.get("callback_port");
         if (callbackPort) {
           sessionStorage.setItem("auth_callback_port", callbackPort);
-          console.log("[LoginForm] Set auth_callback_port in sessionStorage:", callbackPort);
         }
-        console.log("[LoginForm] Set auth_source in sessionStorage");
       } else {
         sessionStorage.removeItem("auth_source");
         sessionStorage.removeItem("auth_callback_port");
-        console.log("[LoginForm] Cleared auth_source and auth_callback_port");
       }
 
       // For desktop flow, redirect directly to desktop-success to keep PKCE state
@@ -67,7 +56,6 @@ export function LoginForm() {
       const callbackUrl = source === "desktop"
         ? `${window.location.origin}/auth/desktop-success`
         : `${window.location.origin}/auth/callback`;
-      console.log("[LoginForm] Callback URL:", callbackUrl);
 
       // For desktop flow, store code_verifier in sessionStorage as backup
       // since cookie storage might not work across page navigations
@@ -77,18 +65,12 @@ export function LoginForm() {
           redirectTo: callbackUrl,
         },
       });
-
-      console.log("[LoginForm] signInWithOAuth result:", { hasData: !!data, hasUrl: !!data?.url, error: error?.message });
-      console.log("[LoginForm] OAuth URL:", data?.url);
       // Check if PKCE is being used (URL should contain code_challenge)
       if (data?.url) {
         const urlHasCodeChallenge = data.url.includes("code_challenge");
-        console.log("[LoginForm] PKCE enabled (has code_challenge):", urlHasCodeChallenge);
       }
       // Log ALL localStorage keys to see where code_verifier is stored
       const allKeys = Object.keys(localStorage);
-      console.log("[LoginForm] All localStorage keys:", allKeys);
-      console.log("[LoginForm] code_verifier key:", allKeys.find(k => k.includes('code-verifier')) || 'NOT FOUND');
 
       if (error) {
         setError(`GitHub OAuth error: ${error.message}`);
@@ -102,8 +84,6 @@ export function LoginForm() {
         setLoading(false);
         return;
       }
-
-      console.log("[LoginForm] Redirecting to Supabase OAuth URL...");
       window.location.href = data.url;
     } catch (e) {
       console.error("[LoginForm] Exception:", e);


### PR DESCRIPTION
### Motivation
- Reduce runtime noise by removing excessive `console.log`/`console.debug`/`console.info` calls that flood logs in editor, auth, and OpenCode flows.
- Preserve actionable error/warning output (`console.error`/`console.warn`) so real failures remain visible for debugging.

### Description
- Stripped noisy debug logging calls (`console.log`/`console.debug`/`console.info`) from desktop code paths including editor page, file-tree drag-and-drop, OpenCode client/hooks, and login-code modal, and from web auth and API routes. 
- Kept error and warning logs intact and left production console-stripping config in `apps/desktop/next.config.ts` unchanged. 
- Changes touch the desktop and web apps (multiple files in `apps/desktop/src/...` and `apps/web/src/...`) and remove the large bulk of transient debug output while preserving behavior.
- Overall reduction: logging-only removals across the UI and OpenCode layers to improve signal-to-noise without functional changes.

### Testing
- Ran TypeScript checks for the web app with `cd apps/web && pnpm tsc --noEmit`, which completed successfully. 
- Ran TypeScript checks for the desktop app with `cd apps/desktop && pnpm tsc --noEmit`, which failed due to an existing workspace module resolution issue (`@lmms-lab/writer-shared` missing) unrelated to this log cleanup. 
- Performed a code search to verify remaining informational console calls are limited to the intended production-stripping configuration (`apps/desktop/next.config.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863d3553e4832bbb19ccc54c62fb95)